### PR TITLE
Add sidebar download button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -486,6 +486,43 @@ main {
 
 .social-item .social-link:hover { color: var(--light-gray); }
 
+/* Download button */
+.download-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  margin-top: 15px;
+  padding: 13px 20px;
+  font-size: var(--fs-6);
+  color: var(--orange-yellow-crayola);
+  background: var(--border-gradient-onyx);
+  border-radius: 14px;
+  box-shadow: var(--shadow-2);
+  z-index: 1;
+  transition: var(--transition-1);
+}
+
+.download-btn::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  background: var(--bg-gradient-jet);
+  border-radius: inherit;
+  z-index: -1;
+  transition: var(--transition-1);
+}
+
+.download-btn:hover {
+  background: var(--bg-gradient-yellow-1);
+}
+
+.download-btn:hover::before {
+  background: var(--bg-gradient-yellow-2);
+}
+
 
 
 

--- a/assets/resume.pdf
+++ b/assets/resume.pdf
@@ -1,0 +1,17 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream\nBT\n/F1 24 Tf\n100 100 Td\n(Placeholder) Tj\nET\nendstream\nendobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref 0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000071 00000 n 
+0000000170 00000 n 
+0000000335 00000 n 
+0000000410 00000 n 
+trailer<</Root 1 0 R/Size 6>>
+startxref
+470
+%%EOF

--- a/index.html
+++ b/index.html
@@ -148,6 +148,11 @@
 
         </ul>
 
+        <a href="assets/resume.pdf" class="download-btn" download>
+          <span>Download CV</span>
+          <ion-icon name="download-outline"></ion-icon>
+        </a>
+
       </div>
 
     </aside>


### PR DESCRIPTION
## Summary
- add dedicated resume download button to sidebar
- style new download button
- include placeholder PDF file

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850216690b083288a4a4d521e2c4eaa