### PR TITLE
Fix mobile icon sizing and add Discord link

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1314,7 +1314,61 @@ textarea.form-input::-webkit-resizer { display: none; }
 
 .form-btn:disabled:hover { background: var(--border-gradient-onyx); }
 
+
 .form-btn:disabled:hover::before { background: var(--bg-gradient-jet); }
+
+/*-----------------------------------*\
+  #PROJECT PAGES
+\*-----------------------------------*/
+
+.platform-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 10px;
+  margin-bottom: 20px;
+}
+
+.platform-title {
+  font-size: var(--fs-4);
+  font-weight: var(--fw-500);
+  color: var(--white-2);
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.platform-tags {
+  display: flex;
+  padding: 10px 16px;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+  border: 1px solid var(--orange-yellow-crayola);
+  border-radius: 12px;
+  background-color: hsla(45, 100%, 72%, 0.05);
+  box-shadow: 0 0 6px hsla(45, 100%, 72%, 0.15);
+}
+
+.platform-link {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.platform-link:hover {
+  transform: scale(1.1);
+}
+
+.platform-icon {
+  width: 28px;
+  height: 28px;
+  opacity: 0.85;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.platform-icon:hover {
+  transform: scale(1.1);
+  opacity: 1;
+}
 
 
 

--- a/index.html
+++ b/index.html
@@ -140,6 +140,12 @@
           </li>
 
           <li class="social-item">
+            <a href="https://discord.com/users/julio.nicacio" class="social-link">
+              <ion-icon name="logo-discord"></ion-icon>
+            </a>
+          </li>
+
+          <li class="social-item">
             <a href="https://bckl.gg/jISN" class="social-link" target="_blank">
               <img src="assets/icons/backloggd-icon-filled-128.png" alt="Backloggd" class="social-img-icon">
             </a>


### PR DESCRIPTION
## Summary
- ensure platform icons scale correctly on mobile by adding base styles
- add Discord social link on sidebar

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850236f7b4c8328a41e8aa8f1284c4b