### PR TITLE
Fix link formatting in Fatal Run section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2461,8 +2461,13 @@ textarea.form-input::-webkit-resizer {
   }
 
   .nowrap {
-  white-space: nowrap;
-}
+    white-space: nowrap;
+    display: inline;
+  }
+
+  .nowrap a {
+    display: inline;
+  }
 
   .tech-list {
     display: flex;


### PR DESCRIPTION
## Summary
- prevent line breaks after inline links in Fatal Run 2089 description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c7d98c58c832880cb08d2e96f7adf