### PR TITLE
Fix inline link formatting

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -137,6 +137,11 @@ span {
   display: block;
 }
 
+/* Ensure punctuation stays attached to links inside paragraphs */
+p a {
+  display: inline;
+}
+
 button {
   font: inherit;
   background: none;
@@ -2461,8 +2466,13 @@ textarea.form-input::-webkit-resizer {
   }
 
   .nowrap {
-  white-space: nowrap;
-}
+    white-space: nowrap;
+    display: inline;
+  }
+
+  .nowrap a {
+    display: inline;
+  }
 
   .tech-list {
     display: flex;


### PR DESCRIPTION
## Summary
- keep punctuation attached to anchor links by overriding `display` for `<p>` anchors

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c7d98c58c832880cb08d2e96f7adf