### PR TITLE
Fix Fatal Run 2089 description overflow

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2465,14 +2465,6 @@ textarea.form-input::-webkit-resizer {
     content: none;
   }
 
-  .nowrap {
-    white-space: nowrap;
-    display: inline;
-  }
-
-  .nowrap a {
-    display: inline;
-  }
 
   .tech-list {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -853,14 +853,10 @@
 
             <p class="trailer-text">
               The latest trailer for <strong>Fatal Run 2089</strong> is now available on the official 
-              <span class="nowrap">
-                <a href="https://www.youtube.com/watch?v=E8cfnrbEvbg" target="_blank">Xbox</a> and 
-                <a href="https://www.youtube.com/watch?v=fsL68bSzixk" target="_blank">PlayStation</a>
-              </span>
-              <span class="nowrap">
-                YouTube channels, as well as in the embedded video below. The game's original reveal trailer was previously featured on 
-                <a href="https://www.youtube.com/watch?v=xbVWlaxpCsE" target="_blank">IGN</a> and other news portals.
-              </span>
+              <a href="https://www.youtube.com/watch?v=E8cfnrbEvbg" target="_blank">Xbox</a> and
+              <a href="https://www.youtube.com/watch?v=fsL68bSzixk" target="_blank">PlayStation</a>
+              YouTube channels, as well as in the embedded video below. The game's original reveal trailer was previously featured on
+              <a href="https://www.youtube.com/watch?v=xbVWlaxpCsE" target="_blank">IGN</a> and other news portals.
             </p>
 
             <div class="container" style="text-align:center; margin-bottom: 32px;">


### PR DESCRIPTION
## Summary
- remove `nowrap` spans from Fatal Run 2089 description so text can wrap
- drop unused `.nowrap` CSS rules

## Testing
- `grep -n "nowrap" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_685c82e08f188328a4d63ed47e426ea6